### PR TITLE
Update SQL lesson "Reference" link to point to W. Trevor King's repo

### DIFF
--- a/index.html
+++ b/index.html
@@ -312,7 +312,7 @@ We will use these Etherpads (<a href="https://etherpad.mozilla.org/2015-04-09-uw
       <li>Combining information from multiple tables using <code>join</code></li>
       <li>Creating, modifying, and deleting data</li>
       <li>Programming with databases</li>
-      <li><a href="http://swcarpentry.github.io/sql-novice-survey/reference.html">Reference...</a></li>
+      <li><a href="https://wking.github.io/swc-sql-novice-survey/reference.html">Reference...</a></li>
     </ul>
   </div>
 </div>


### PR DESCRIPTION
Matches the schedule link which was updated in 45dd465 (index.html:
Point folks at my version of the SQL lesson, 2015-04-06).

Note that the final lesson isn't merged into the gh-pages branch of
wking's repo, so it's not live on the web (yet).

This complements #14 which was merged a little bit ago by @benmarwick.
